### PR TITLE
Updated updateProfile endpoint

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -56,7 +56,7 @@ class Client {
    * @returns {Promise} - Returned promise
    */
   updateProfile (steamid64) {
-    return this.post(`/profile/${steamid64}/update`)
+    return this.post(`/profile/${steamid64}/`)
   }
 
   /**


### PR DESCRIPTION
The update profile endpoint was wrongly documented on Steam Ladder. I just fixed this! You can updated a profile by POSTing to the same endpoint as the getProfile endpoint now.